### PR TITLE
Addec custom stars Solar Attributes

### DIFF
--- a/plugin/data/stars.txt
+++ b/plugin/data/stars.txt
@@ -1,0 +1,336 @@
+# Copyright (c) 2017 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+# Star attributes (solar power and solar wind). In general, a star either
+# provides a lot of solar power or a lot of solar wind (ramscoop recharge rate)
+# but not both. That's not realistic, but it creates a more interesting dynamic.
+
+# For convenience, every spectral class (o, b, a, f, g, k, m) has the same variants:
+# 0, 3, 5, 8, -dwarf, -giant, and -supergiant
+
+# Main sequence stars.
+star "star/o0"
+	power 4.2
+	wind 0.46
+star "star/o3"
+	power 3.9
+	wind 0.46
+star "star/o5"
+	power 3.6
+	wind 0.47
+star "star/o8"
+	power 3.3
+	wind 0.48
+star "star/b0"
+	power 3.1
+	wind 0.49
+star "star/b3"
+	power 2.8
+	wind 0.5
+star "star/b5"
+	power 2.5
+	wind 0.51
+star "star/b8"
+	power 2.2
+	wind 0.52
+star "star/a0"
+	power 2
+	wind 0.53
+star "star/a3"
+	power 1.85
+	wind 0.54
+star "star/a5"
+	power 1.7
+	wind 0.55
+star "star/a8"
+	power 1.5
+	wind 0.56
+star "star/f0"
+	power 1.4
+	wind 0.57
+star "star/f3"
+	power 1.3
+	wind 0.59
+star "star/f5"
+	power 1.2
+	wind 0.60
+star "star/f8"
+	power 1.1
+	wind 0.62
+star "star/g0"
+	power 1
+	wind 0.64
+star "star/g3"
+	power 0.95
+	wind 0.66
+star "star/g5"
+	power 0.9
+	wind 0.69
+star "star/g8"
+	power 0.85
+	wind 0.72
+star "star/k0"
+	power 0.8
+	wind 0.75
+star "star/k3"
+	power 0.76
+	wind 0.78
+star "star/k5"
+	power 0.72
+	wind 0.82
+star "star/k8"
+	power 0.7
+	wind 0.86
+star "star/m0"
+	power 0.66
+	wind 0.90
+star "star/m3"
+	power 0.64
+	wind 0.95
+star "star/m5"
+	power 0.61
+	wind 1.05
+star "star/m8"
+	power 0.60
+	wind 1.10
+star "star/x0"
+	power 1
+	wind 1
+star "star/x3"
+	power 1.1
+	wind 1.05
+star "star/x4"
+	power 0.9
+	wind 1.15
+star "star/x8"
+	power 1
+	wind 1.17
+star "star/xg0"
+	power 1.9
+	wind 0.52
+star "star/xg3"
+	power 1.82
+	wind 0.50
+star "star/xg4"
+	power 1.5
+	wind 0.45
+star "star/xg8"
+	power 1.2
+	wind 0.48
+star "star/y0"
+	power 2.2
+	wind 0.89
+star "star/y3"
+	power 1.95
+	wind 0.70
+star "star/y5"
+	power 1.8
+	wind 0.65
+star "star/y8"
+	power 1.6
+	wind 0.54
+
+# Old main sequence stars.
+star "star/f5-old"
+	power 0.80
+	wind 0.9
+star "star/g0-old"
+	power 0.70
+	wind 1.0
+star "star/g5-old"
+	power 0.65
+	wind 1.1
+star "star/k0-old"
+	power 0.62
+	wind 1.3
+star "star/k5-old"
+	power 0.60
+	wind 1.5
+star "star/x0-old"
+      power 0.7
+      wind 1.7
+star "star/x5-old"
+      power 0.8
+      wind 1.8
+star "star-xg0-old"
+      power 0.85
+      wind 0.8
+star "star/xg5-old"
+      power 0.80
+      wind 0.6
+
+# Giant and supergiant stars.
+star "star/o-giant"
+	power 4.8
+	wind 1.5
+star "star/b-giant"
+	power 3.7
+	wind 1.6
+star "star/a-giant"
+	power 2.6
+	wind 1.7
+star "star/f-giant"
+	power 2.0
+	wind 1.8
+star "star/g-giant"
+	power 1.6
+	wind 1.9
+star "star/k-giant"
+	power 1.4
+	wind 2
+star "star/m-giant"
+	power 1.2
+	wind 2.1
+star "star/x-giant"
+      power 1.25
+      wind 2.2
+star "star/xgiant"
+      power 1.1
+      wind 2.4
+star "star/xg-giant"
+      power 2.3
+      wind 1.9
+star "star/xggiant"
+      power 2
+      wind 2.5
+star "star/y-giant"
+      power 2.6
+      wind 2.1
+star "star/o-supergiant"
+	power 5.2
+	wind 2.5
+star "star/b-supergiant"
+	power 4.1
+	wind 2.6
+star "star/a-supergiant"
+	power 3
+	wind 2.7
+star "star/f-supergiant"
+	power 2.4
+	wind 2.8
+star "star/g-supergiant"
+	power 2
+	wind 2.9
+star "star/k-supergiant"
+	power 1.8
+	wind 3
+star "star/m-supergiant"
+	power 1.6
+	wind 3.1
+star "star/x-supergiant"
+      power 1.7
+      wind 3.2
+star "star/xg-supergiant"
+      power 2.7
+      wind 2.5
+star "star/y-supergiant"
+      power 2.9
+      wind 2.7
+
+# Special stars.
+star "star/carbon"
+	power 0.1
+	wind 10
+star "star/nova"
+	power 0.2
+	wind 8
+star "star/nova-old"
+	power 0.3
+	wind 6
+star "star/nova-small"
+	power 0.2
+	wind 4
+star "star/wr"
+	power 5
+	wind 4
+star "star/protostar-orange"
+	power 0.5
+	wind 3
+star "star/protostar-yellow"
+	power 0.4
+	wind 5
+
+# Rogue planet with unusual properties
+star "planet/rogue-radiating"
+	power .2
+	wind .6
+
+star "star/neutron"
+	power 4
+	wind 0.4
+
+star "star/red neutron"
+      power 3.2
+      wind 9
+
+# Dwarves scaled like stars.
+star "star/o-dwarf"
+	power 1.1
+	wind 0.5
+star "star/b-dwarf"
+	power 1
+	wind 0.6
+star "star/a-dwarf"
+	power 0.9
+	wind 0.7
+star "star/f-dwarf"
+	power 0.8
+	wind 0.8
+star "star/g-dwarf"
+	power 0.7
+	wind 0.9
+star "star/k-dwarf"
+	power 0.6
+	wind 1
+star "star/m-dwarf"
+	power 0.5
+	wind 1.2
+star "star/l-dwarf"
+	power 0.4
+	wind 1.3
+star "star/x-dwarf"
+      power 0.5
+      wind 1.35
+star "star/xg-dwarf"
+      power 0.7
+      wind 0.4
+
+# Brown Dwarves
+# Because these look like planets, they reverse the trend of increasing solar wind
+
+star "planet/browndwarf-l"
+	power 0.4
+	wind 0.5
+star "planet/browndwarf-l-rouge"
+	power 0.4
+	wind 0.5
+star "planet/browndwarf-t"
+	power 0.3
+	wind 0.4
+star "planet/browndwarf-t-rouge"
+	power 0.3
+	wind 0.4
+star "planet/browndwarf-y"
+	power 0.1
+	wind 0.3
+star "planet/browndwarf-y-rouge"
+	power 0.1
+	wind 0.3
+
+# Extra stars kept for backwards compatibility.
+star "star/m4"
+	power 0.62
+	wind 1.00
+star "star/giant"
+	power 1.4
+	wind 2


### PR DESCRIPTION
Added the new types of stars(x; xg; y and the red neutron that can be found in the Lifdot system) to stars.txt which contains every Solar Attributes.

https://github.com/OcelotWalrus/Cromha-Expansion-plugin/issues/82